### PR TITLE
Create a Title widget and add ProjectTitle to string table.

### DIFF
--- a/Content/Virtue/Configuration/ST_UIStrings.uasset
+++ b/Content/Virtue/Configuration/ST_UIStrings.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:42c6e4b8461cc587f0fcd27632e5834ba60f341b2bf32c5572925c6d1a48165c
-size 3491
+oid sha256:bfc91a5e71790f35cd3e3e5b870e93ea449bc82d40e0b8bcbb946ec1e3c80f59
+size 3609

--- a/Content/Virtue/Interface/BPW_Title.uasset
+++ b/Content/Virtue/Interface/BPW_Title.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:069297d4f48e4d3fb7f9bc55cf82c136bf8a679b3ace360ec8f87357428ac340
+size 24679


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/4bb6d80c-9382-4f6d-abdc-68e12e6174bf)

Created a title widget and created the project title string with the value set to Virtue.
Use transform policy upper to ensure the text is displayed in upper case.